### PR TITLE
remove zstandard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
 dependencies = [
     "typing-extensions>=4.4.0,<5",
     "theine-core>=2.0.0,<3",
-    "zstandard>=0.24.0.dev0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1205,7 +1205,6 @@ source = { editable = "." }
 dependencies = [
     { name = "theine-core" },
     { name = "typing-extensions" },
-    { name = "zstandard" },
 ]
 
 [package.dev-dependencies]
@@ -1238,7 +1237,6 @@ dev = [
 requires-dist = [
     { name = "theine-core", specifier = ">=2.0.0,<3" },
     { name = "typing-extensions", specifier = ">=4.4.0,<5" },
-    { name = "zstandard", git = "https://github.com/dpdani/python-zstandard.git?branch=feature%2F3.13t" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Zstandard is only used for benchmarking; remove Zstandard from the dependencies.